### PR TITLE
Fix for issue 70

### DIFF
--- a/docs/v1/Set-EasitService.md
+++ b/docs/v1/Set-EasitService.md
@@ -13,7 +13,7 @@ Private cmdlet, not used by user directly.
 
 ## SYNTAX
 
-```
+```powershell
 Set-EasitService [-Service] <CimInstance> [-Action] <String> [<CommonParameters>]
 ```
 
@@ -75,14 +75,17 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None
+
 ## OUTPUTS
 
 ### System.Object
+
 ## NOTES
 
 ## RELATED LINKS

--- a/source/private/Set-EasitService.ps1
+++ b/source/private/Set-EasitService.ps1
@@ -29,12 +29,12 @@ function Set-EasitService {
         try {
             do {
                 Write-Verbose "Waiting for service to complete method invokation"
-                Start-Sleep -Seconds 15
-                $waitingTime += 15
+                Start-Sleep -Seconds 5
+                $waitingTime += 5
                 $serviceToCheck = Get-CimInstance -InputObject $Service
             } while ($serviceToCheck.State -ne "$waitForServiceState" -AND $waitingTime -le 240)
             if ($waitingTime -gt 240) {
-                Write-Warning "Time to start service exceeded 2 minutes, please look in logs for any problems"
+                Write-Warning "Time to invoke method $Action exceeded 2 minutes"
             }
         } catch {
             throw $_


### PR DESCRIPTION
Fixes includes:
- Changed warning message for when invokation waiting time have passed 2 minutes from 'Time to start service exceeded 2 minutes, please look in logs for any problems' to 'Time to invoke method $Action exceeded 2 minutes'
- Changed "Start-Sleep" from 15 to 5 seconds in order to get quicker return when invokation have been completed successfully.