### PR TITLE
Fixes for issue #82

### DIFF
--- a/source/public/Get-EMFConfig.ps1
+++ b/source/public/Get-EMFConfig.ps1
@@ -6,12 +6,12 @@ function Get-EMFConfig {
         [string] $EMFHome = "$Home\EMF",
         
         [Parameter()]
-        [Alias('file','filename')]
-        [string] $ConfigurationFileName = 'emfConfig.xml',
+        [Alias('ConfigurationFileName','ConfigFile','ConfigFileName')]
+        [string] $EmfConfigurationFileName = 'emfConfig.xml',
 
         [Parameter(Mandatory, Position=0)]
-        [Alias('ConfigName')]
-        [string] $ConfigurationName
+        [Alias('ConfigurationName','ConfigName')]
+        [string] $EmfConfigurationName
     )
     
     begin {

--- a/source/public/Invoke-EasitGOUpdate.ps1
+++ b/source/public/Invoke-EasitGOUpdate.ps1
@@ -188,7 +188,7 @@ function Invoke-EasitGOUpdate {
         Write-Information "Starting update process for Easit GO" -InformationAction Continue
         Write-Information "Stopping service" -InformationAction Continue
         try {
-            $service = Stop-EasitGOApplication -EMFHome $EmfHome -ConfigurationFileName $EmfConfigurationFileName -ConfigurationName $EmfConfigurationName -RunningElevated $RunningElevated
+            $service = Stop-EasitGOApplication -EMFHome $EmfHome -ConfigurationFileName $EmfConfigurationFileName -ConfigurationName $EmfConfigurationName -RunningElevated:$RunningElevated
         } catch {
             throw $_
         }
@@ -239,18 +239,18 @@ function Invoke-EasitGOUpdate {
             }
         }
         try {
-            Remove-Item "$logsRoot\*.*" -Recurse -Force -InformationAction SilentlyContinue
+            Remove-Item "$logsRoot" -Include '*.*' -Recurse -Force -Confirm:$false -InformationAction SilentlyContinue
         } catch {
             Write-Warning "$($_.Exception)"
         }
         try {
-            Remove-Item "$warFile" -InformationAction SilentlyContinue
+            Remove-Item "$warFile" -Confirm:$false -InformationAction SilentlyContinue
         } catch {
             Write-Warning "$($_.Exception)"
         }
         $expandedWarFolder = Join-Path -Path "$webappsRoot" -ChildPath "$($emfConfig.WarName)"
         try {
-            Remove-Item "$expandedWarFolder" -InformationAction SilentlyContinue
+            Remove-Item "$expandedWarFolder" -Confirm:$false -InformationAction SilentlyContinue
         } catch {
             Write-Warning "$($_.Exception)"
         }
@@ -270,7 +270,7 @@ function Invoke-EasitGOUpdate {
         }
         Write-Information "Starting service" -InformationAction Continue
         try {
-            $service = Start-EasitGOApplication -EMFHome $EmfHome -ConfigurationFileName $EmfConfigurationFileName -ConfigurationName $EmfConfigurationName -Verify -RunningElevated $RunningElevated
+            $service = Start-EasitGOApplication -EMFHome $EmfHome -ConfigurationFileName $EmfConfigurationFileName -ConfigurationName $EmfConfigurationName -Verify -RunningElevated:$RunningElevated
         } catch {
             throw $_
         }

--- a/source/public/New-EMFConfig.ps1
+++ b/source/public/New-EMFConfig.ps1
@@ -6,17 +6,17 @@ function New-EMFConfig {
         [string] $EMFHome = "$Home\EMF",
         
         [Parameter()]
-        [Alias('file','filename')]
-        [string] $ConfigurationFileName = 'emfConfig.xml',
+        [Alias('ConfigurationFileName','ConfigFile','ConfigFileName')]
+        [string] $EmfConfigurationFileName = 'emfConfig.xml',
         
         [Parameter(Mandatory)]
         [ValidateSet("Prod","Test","Dev","IntegrationProd","IntegrationTest","IntegrationDev")]
-        [Alias('ConfigName')]
-        [string] $ConfigurationName,
+        [Alias('ConfigurationName','ConfigName')]
+        [string] $EmfConfigurationName,
 
         [Parameter(Mandatory)]
-        [Alias('ConfigSettings')]
-        [hashtable] $ConfigurationSettings,
+        [Alias('ConfigurationSettings','ConfigSettings')]
+        [hashtable] $EmfConfigurationSettings,
 
         [Parameter()]
         [switch ] $Validate,
@@ -30,7 +30,6 @@ function New-EMFConfig {
     }
     
     process {
-    Write-Verbose "Process block start!"
         $emfConfigFilePath = "$EMFHome\$ConfigurationFileName"
         if (Test-Path "$emfConfigFilePath") {
             Write-Verbose -Message "$emfConfigFilePath already exists."

--- a/source/public/Set-EMFConfig.ps1
+++ b/source/public/Set-EMFConfig.ps1
@@ -6,12 +6,12 @@ function Set-EMFConfig {
         [string] $EMFHome = "$Home\EMF",
 
         [Parameter()]
-        [Alias('file','filename')]
-        [string] $ConfigurationFileName = 'emfConfig.xml',
+        [Alias('ConfigurationFileName','ConfigFile','ConfigFileName')]
+        [string] $EmfConfigurationFileName = 'emfConfig.xml',
 
         [Parameter(Mandatory,Position=0)]
-        [Alias('ConfigName')]
-        [string] $ConfigurationName,
+        [Alias('ConfigurationName','ConfigName')]
+        [string] $EmfConfigurationName,
 
         [Parameter(Mandatory,ParameterSetName='Manual')]
         [string] $EasitRoot,

--- a/source/public/Start-EasitGOApplication.ps1
+++ b/source/public/Start-EasitGOApplication.ps1
@@ -3,12 +3,18 @@ function Start-EasitGOApplication {
     param (
         [Parameter()]
         [string] $EmfHome = "$Home\EMF",
+
         [Parameter()]
+        [Alias('ConfigurationFileName','ConfigFile','ConfigFileName')]
         [string] $EmfConfigurationFileName = 'emfConfig.xml',
+
         [Parameter()]
+        [Alias('ConfigurationName','ConfigName')]
         [string] $EmfConfigurationName = 'Dev',
+
         [Parameter()]
         [switch] $Verify,
+        
         [Parameter()]
         [switch] $RunningElevated
     )

--- a/source/public/Stop-EasitGOApplication.ps1
+++ b/source/public/Stop-EasitGOApplication.ps1
@@ -3,10 +3,15 @@ function Stop-EasitGOApplication {
     param (
         [Parameter()]
         [string] $EmfHome = "$Home\EMF",
+
         [Parameter()]
+        [Alias('ConfigurationFileName','ConfigFile','ConfigFileName')]
         [string] $EmfConfigurationFileName = 'emfConfig.xml',
+
         [Parameter()]
+        [Alias('ConfigurationName','ConfigName')]
         [string] $EmfConfigurationName = 'Dev',
+        
         [Parameter()]
         [switch] $RunningElevated
     )

--- a/tests/Get-EMFConfig.Tests.ps1
+++ b/tests/Get-EMFConfig.Tests.ps1
@@ -13,14 +13,14 @@ Describe 'Parameters' {
             Write-Host "Unable to locate code file to test against!" -ForegroundColor Red
         }
     }
-    It 'ConfigurationFileName should not be mandatory' {
-        Get-Command "$commandName" | Should -HaveParameter ConfigurationFileName -Not -Mandatory
+    It 'EmfConfigurationFileName should not be mandatory' {
+        Get-Command "$commandName" | Should -HaveParameter EmfConfigurationFileName -Not -Mandatory
     }
     It 'ConfigurationFileName should have a value' {
-        Get-Command "$commandName" | Should -HaveParameter ConfigurationFileName -DefaultValue 'emfConfig.xml'
+        Get-Command "$commandName" | Should -HaveParameter EmfConfigurationFileName -DefaultValue 'emfConfig.xml'
     }
     It 'ConfigurationName should be mandatory' {
-        Get-Command "$commandName" | Should -HaveParameter ConfigurationName -Mandatory
+        Get-Command "$commandName" | Should -HaveParameter EmfConfigurationName -Mandatory
     }
     It 'ConfigurationName should be null' {
         $ConfigurationName | Should -BeNullOrEmpty

--- a/tests/New-EMFConfig.Tests.ps1
+++ b/tests/New-EMFConfig.Tests.ps1
@@ -19,22 +19,22 @@ Describe 'Parameters' {
     It 'EMFHome should have a value' {
         Get-Command "$commandName" | Should -HaveParameter EMFHome -DefaultValue '$Home\EMF'
     }
-    It 'ConfigurationFileName should not be mandatory' {
-        Get-Command "$commandName" | Should -HaveParameter ConfigurationFileName -Not -Mandatory
+    It 'EmfConfigurationFileName should not be mandatory' {
+        Get-Command "$commandName" | Should -HaveParameter EmfConfigurationFileName -Not -Mandatory
     }
-    It 'ConfigurationFileName should have a value' {
-        Get-Command "$commandName" | Should -HaveParameter ConfigurationFileName -DefaultValue 'emfConfig.xml'
+    It 'EmfConfigurationFileName should have a value' {
+        Get-Command "$commandName" | Should -HaveParameter EmfConfigurationFileName -DefaultValue 'emfConfig.xml'
     }
-    It 'ConfigurationName should be mandatory' {
-        Get-Command "$commandName" | Should -HaveParameter ConfigurationName -Mandatory
+    It 'EmfConfigurationName should be mandatory' {
+        Get-Command "$commandName" | Should -HaveParameter EmfConfigurationName -Mandatory
     }
-    It 'ConfigurationName should be null' {
+    It 'EmfConfigurationName should be null' {
         $ConfigurationName | Should -BeNullOrEmpty
     }
-    It 'ConfigurationSettings should be mandatory' {
-        Get-Command "$commandName" | Should -HaveParameter ConfigurationSettings -Mandatory
+    It 'EmfConfigurationSettings should be mandatory' {
+        Get-Command "$commandName" | Should -HaveParameter EmfConfigurationSettings -Mandatory
     }
-    It 'ConfigurationSettings should be a hashtable' {
+    It 'EmfConfigurationSettings should be a hashtable' {
         $ConfigSettings = @{}
         $ConfigSettings | Should -BeOfType [System.Collections.Hashtable]
     }
@@ -42,11 +42,11 @@ Describe 'Parameters' {
         $ConfigSettings = @{}
         $ConfigSettings | Should -BeNullOrEmpty
     }
-    It 'ValidateConfig should not be mandatory' {
-        Get-Command "$commandName" | Should -HaveParameter ValidateConfig -Not -Mandatory
+    It 'Validate should not be mandatory' {
+        Get-Command "$commandName" | Should -HaveParameter Validate -Not -Mandatory
     }
-    It 'ValidateConfig should be a switch' {
-        [switch]$ValidateConfig = $false
-        $ValidateConfig | Should -BeOfType [System.Management.Automation.SwitchParameter]
+    It 'Validate should be a switch' {
+        [switch]$Validate = $false
+        $Validate | Should -BeOfType [System.Management.Automation.SwitchParameter]
     }
 }

--- a/tests/Set-EMFConfig.Tests.ps1
+++ b/tests/Set-EMFConfig.Tests.ps1
@@ -19,19 +19,26 @@ Describe 'Parameters' {
     It 'EMFHome should have a value' {
         Get-Command "$commandName" | Should -HaveParameter EMFHome -DefaultValue '$Home\EMF'
     }
-    It 'ConfigurationFileName should not be mandatory' {
-        Get-Command "$commandName" | Should -HaveParameter ConfigurationFileName -Not -Mandatory
+    It 'EmfConfigurationFileName should not be mandatory' {
+        Get-Command "$commandName" | Should -HaveParameter EmfConfigurationFileName -Not -Mandatory
     }
-    It 'ConfigurationFileName should have a value' {
-        Get-Command "$commandName" | Should -HaveParameter ConfigurationFileName -DefaultValue 'emfConfig.xml'
+    It 'EmfConfigurationFileName should have a value' {
+        Get-Command "$commandName" | Should -HaveParameter EmfConfigurationFileName -DefaultValue 'emfConfig.xml'
     }
-    It 'ConfigurationName should be mandatory' {
-        Get-Command "$commandName" | Should -HaveParameter ConfigurationName -Mandatory
+    It 'EmfConfigurationName should be mandatory' {
+        Get-Command "$commandName" | Should -HaveParameter EmfConfigurationName -Mandatory
     }
-    It 'ConfigurationName should be null' {
-        $ConfigurationName | Should -BeNullOrEmpty
+    It 'EmfConfigurationName should be null' {
+        $EmfConfigurationName | Should -BeNullOrEmpty
     }
     It 'PropertySetting should be mandatory' {
         Get-Command "$commandName" | Should -HaveParameter PropertySetting -Mandatory
+    }
+    It 'ValidateSettings should not be mandatory' {
+        Get-Command "$commandName" | Should -HaveParameter ValidateSettings -Not -Mandatory
+    }
+    It 'ValidateSettings should be a switch' {
+        [switch]$ValidateSettings = $false
+        $ValidateSettings | Should -BeOfType [System.Management.Automation.SwitchParameter]
     }
 }


### PR DESCRIPTION
Fixes includes:
- Gave aliases to parameters EmfConfigurationFileName and EmfConfigurationName in Get-EMFConfig, New-EMFConfig and Set-EMFConfig, Start-EasitGOApplication, Stop-EasitGOApplication.
- Changed how parameter RunningElevated was used in Invoke-EasitGOUpdate from -RunningElevated $RunningElevated to -RunningElevated:$RunningElevated
- Overhaul of files/folder backup procedure.
- Overhaul of how Remove-Item was used to prevent popup asking for confirmation.