### PR TITLE
Fixed incorrect parsing of dataSource url

### DIFF
--- a/docs/v1/Get-DatabaseDetails.md
+++ b/docs/v1/Get-DatabaseDetails.md
@@ -1,0 +1,68 @@
+---
+external help file: EasitManagementFramework-help.xml
+Module Name: EasitManagementFramework
+online version: https://github.com/easitab/EasitManagementFramework/blob/development/docs/v1/Get-DatabaseDetails.md
+schema: 2.0.0
+---
+
+# Get-DatabaseDetails
+
+## SYNOPSIS
+
+Private function used to split dataSource.url from properties.xml
+
+## SYNTAX
+
+```powershell
+Get-DatabaseDetails [-Uri] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Splits / Parses an url into dbName, dbServerName, dbPort, dbInstance.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> Get-DatabaseDetails -Uri 'jdbc:sqlserver://serverUrl:port\\instanceName;databaseName=nameOfDatabase'
+
+dbServerName dbServerPort dbInstance   dbName
+------------ ------------ ----------   ------
+serverUrl    port         instanceName nameOfDatabase
+```
+
+## PARAMETERS
+
+### -Uri
+
+String to parse / split
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/source/private/Get-DatabaseDetails.ps1
+++ b/source/private/Get-DatabaseDetails.ps1
@@ -1,0 +1,94 @@
+function Get-DatabaseDetails {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]$Uri
+    )
+    
+    begin {
+        Write-Verbose "$($MyInvocation.MyCommand) initialized"
+    }
+    
+    process {
+        $returnObject = New-Object PSObject
+        $multiConnDets = $false
+        if ($Uri -match 'sqlserver') {
+            Write-Verbose "ConnString is for MSSQL"
+            $supportedProtocol = $true
+            $dbConnectionDetails = $Uri -split ';'
+            if ($dbConnectionDetails.Count -ne '1') {
+                $multiConnDets = $true
+            }
+        }
+        if ($Uri -match 'mysql') {
+            Write-Verbose "ConnString is for MySQL"
+            $supportedProtocol = $false
+            $cleanDbUrl = $Uri -replace '.+\:.+\:\/\/',''
+            Write-Verbose "cleanDbUrl = $cleanDbUrl"
+            $dbName = Split-Path $cleanDbUrl -Leaf
+            $dbServerUrl = Split-Path $cleanDbUrl -Parent
+            $dbServerUrlDetails = $dbServerUrl -split ':'
+            $dbServerName = $dbServerUrlDetails[0]
+            if ($dbServerUrlDetails[1]) {
+                $dbServerPort = $dbServerUrlDetails[1]
+            } else {
+                $dbServerPort = 3306
+            }
+        }
+        
+        if ($multiConnDets) {
+            Write-Verbose "Multiple connections details"
+            foreach ($dbConnectionDetail in $dbConnectionDetails) {
+                Write-Verbose $dbConnectionDetail
+                if ($dbConnectionDetail -match '.+\:.+\:\/\/.*') {
+                    $dbServerDetails = $dbConnectionDetail -replace '.+\:.+\:\/\/',''
+                    if ($dbServerDetails -match '\\\\') {
+                        Write-Verbose "$dbServerDetails contains \\"
+                        $dbInstanceDetails = $dbServerDetails -split '\\\\'
+                        Write-Verbose "dbInstanceDetails = $dbInstanceDetails"
+                        $dbInstance = $dbInstanceDetails[1]
+                        $dbServerDetails = $dbInstanceDetails[0]
+                    }
+                    if ($dbServerDetails -match ':') {
+                        Write-Verbose "$dbServerDetails contains :"
+                        $dbServerUrlDetails = $dbServerDetails -split ':'
+                        Write-Verbose "dbServerUrlDetails = $dbServerUrlDetails"
+                        $dbServerName = $dbServerUrlDetails[0]
+                        $dbServerPort = $dbServerUrlDetails[1]
+                    } 
+                    if (!($dbServerName)) {
+                        $dbServerName = $dbServerDetails
+                    }
+                    if (!($dbServerPort)) {
+                        $dbServerPort = 1433
+                    }
+                    if (!($dbInstance)) {
+                        $dbInstance = $null
+                    }
+                }
+                if ($dbConnectionDetail -match 'databaseName.*') {
+                    $dbName = $dbConnectionDetail -replace 'databaseName=',''
+                }
+            }
+        }
+        try {
+            Write-Verbose "dbServerName = $dbServerName"
+            $returnObject | Add-Member -MemberType NoteProperty -Name 'dbServerName' -Value "$dbServerName"
+            Write-Verbose "dbServerPort = $dbServerPort"
+            $returnObject | Add-Member -MemberType NoteProperty -Name 'dbServerPort' -Value "$dbServerPort"
+            Write-Verbose "dbName = $dbName"
+            $returnObject | Add-Member -MemberType NoteProperty -Name 'dbName' -Value "$dbName"
+            Write-Verbose "dbInstance = $dbInstance"
+            $returnObject | Add-Member -MemberType NoteProperty -Name 'dbInstance' -Value "$dbInstance"
+            Write-Verbose "supportedProtocol = $supportedProtocol"
+            $returnObject | Add-Member -MemberType NoteProperty -Name 'supportedProtocol' -Value "$supportedProtocol"
+            return $returnObject
+        } catch {
+            throw $_
+        }
+    }
+    
+    end {
+        Write-Verbose "$($MyInvocation.MyCommand) completed"
+    }
+}

--- a/tests/Get-DatabaseDetails.Tests.ps1
+++ b/tests/Get-DatabaseDetails.Tests.ps1
@@ -1,0 +1,19 @@
+Describe 'Parameters' {
+    BeforeAll {
+        $testFilePath = $PSCommandPath.Replace('.Tests.ps1','.ps1')
+        $codeFileName = Split-Path -Path $testFilePath -Leaf
+        $commandName = ((Split-Path -Leaf $PSCommandPath) -replace '.ps1','') -replace '.Tests', ''
+        $testRoot = Split-Path -Path $PSCommandPath -Parent
+        $projectRoot = Split-Path -Path $testRoot -Parent
+        $sourceRoot = Join-Path -Path "$projectRoot" -ChildPath "source"
+        $codeFile = Get-ChildItem -Path "$sourceRoot" -Include "$codeFileName" -Recurse
+        if (Test-Path $codeFile) {
+            . $codeFile
+        } else {
+            Write-Host "Unable to locate code file to test against!" -ForegroundColor Red
+        }
+    }
+    It 'Uri should be mandatory' {
+        Get-Command "$commandName" | Should -HaveParameter Uri -Mandatory
+    }
+}


### PR DESCRIPTION
When running 'Invoke-EasitGOUpdate' you could get an error (Cannot index into a null array) if url to database in properties.xml was in this format: jdbc:sqlserver://xxx;databaseName=xxx
This have been addressed by adding new function that parses / split dataSource url.