### PR TITLE
Improved function - Get-EasitEmailRequestMailbox

### DIFF
--- a/docs/v1/Convert-EmailRequestConfigfile.md
+++ b/docs/v1/Convert-EmailRequestConfigfile.md
@@ -1,0 +1,64 @@
+---
+external help file: EasitManagementFramework-help.xml
+Module Name: EasitManagementFramework
+online version: https://github.com/easitab/EasitManagementFramework/blob/development/docs/v1/Convert-EmailRequestConfigfile.md
+schema: 2.0.0
+---
+
+# Convert-EmailRequestConfigfile
+
+## SYNOPSIS
+
+Private function to convert mailboxes in EmailRequest configuration files into PS Objects.
+
+## SYNTAX
+
+```powershell
+Convert-EmailRequestConfigfile [-Path] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> Convert-EmailRequestConfigfile -Path "D:\Easit\EmailRequest\config_prod.xml"
+```
+
+## PARAMETERS
+
+### -Path
+
+Literal path to configuration file to convert.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/v1/Get-EasitEmailRequestMailbox.md
+++ b/docs/v1/Get-EasitEmailRequestMailbox.md
@@ -38,26 +38,18 @@ In this example we will get all mailboxes configured for EmailRequest.
 ### Example 2
 
 ```powershell
-PS C:\> Get-EasitEmailRequestMailbox -MailboxName POP3Test
+PS C:\> Get-EasitEmailRequestMailbox -EmailRequestConfigurationFilename '*config*.xml' | Out-GridView
 ```
 
-In this example we will get all settings for a mailbox with *POP3Test* as its displayName.
+This example will return all mailboxes from all files with xml files that have a name containing config and display them in a grid view.
 
-### Example 3
+### Example 2
 
 ```powershell
-PS C:\> Get-EasitEmailRequestMailbox -MailboxName POP3Test -EmfConfigurationName Test
+PS C:\> Get-EasitEmailRequestMailbox -EmailRequestConfigurationFilename 'config_prod.xml' -MailboxName '*prod*' | Out-GridView
 ```
 
-In this example we will get all settings for a mailbox with *POP3Test* as its displayName in config.xml in the folder provided in EmailRequestRoot for EMF-configuration Test.
-
-### Example 4
-
-```powershell
-PS C:\> Get-EasitEmailRequestMailbox -MailboxName POP3Test -EmailRequestConfigurationFilename config_test.xml
-```
-
-In this example we will get all settings for a mailbox with *POP3Test* as its displayName in config_test.xml. Use this syntax if you have multiple configurationfiles for EmailRequest.
+This example will return all mailboxes with a displayName containing the word *prod* from the configuration file named *config_prod.xml* and display them in a grid view.
 
 ## PARAMETERS
 

--- a/source/private/Convert-EmailRequestConfigfile.ps1
+++ b/source/private/Convert-EmailRequestConfigfile.ps1
@@ -1,0 +1,55 @@
+function Convert-EmailRequestConfigfile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+    
+    begin {
+        Write-Verbose "$($MyInvocation.MyCommand) initialized"
+    }
+    
+    process {
+        try {
+            $xmlObject = New-Object XML
+        } catch {
+            throw $_
+        }
+        if (Test-Path $Path) {
+            try {
+                $xmlObject.Load($Path)
+            } catch {
+                throw $_
+            }
+        } else {
+            throw "Unable to find $Path"
+        }
+        foreach ($entry in $xmlObject.configuration.entries.GetEnumerator()) {
+            try {
+                $erMailConfigAsPSObject = New-Object PSObject
+            } catch {
+                throw $_
+            }
+            foreach ($mainProperty in $entry.properties.GetEnumerator()) {
+                Write-Verbose "Adding property $($mainProperty.name) = $($mainProperty.value)"
+                Add-Member -InputObject $erMailConfigAsPSObject -MemberType NoteProperty -Name "$($mainProperty.name)" -Value "$($mainProperty.value)"
+            }
+            foreach ($sourceProperty in $entry.source.properties.GetEnumerator()) {
+                Write-Verbose "Adding property $($sourceProperty.name) = $($sourceProperty.value)"
+                Add-Member -InputObject $erMailConfigAsPSObject -MemberType NoteProperty -Name "$($sourceProperty.name)" -Value "$($sourceProperty.value)"
+            }
+            foreach ($destinationProperty in $entry.destination.properties.GetEnumerator()) {
+                Write-Verbose "Adding property $($destinationProperty.name) = $($destinationProperty.value)"
+                Add-Member -InputObject $erMailConfigAsPSObject -MemberType NoteProperty -Name "$($destinationProperty.name)" -Value "$($destinationProperty.value)"
+            }
+            Write-Verbose "Adding property sourceType = $($entry.source.type)"
+            Add-Member -InputObject $erMailConfigAsPSObject -MemberType NoteProperty -Name 'sourceType' -Value "$($entry.source.type)"
+            Add-Member -InputObject $erMailConfigAsPSObject -MemberType NoteProperty -Name 'Path' -Value "$Path"
+            $erMailConfigAsPSObject
+        }
+    }
+    
+    end {
+        Write-Verbose "$($MyInvocation.MyCommand) completed"
+    }
+}

--- a/source/public/Get-EasitEmailRequestMailbox.ps1
+++ b/source/public/Get-EasitEmailRequestMailbox.ps1
@@ -11,11 +11,11 @@ function Get-EasitEmailRequestMailbox {
         [string] $EmfConfigurationName = 'Prod',
 
         [Parameter()]
-        [string] $EmailRequestConfigurationFilename = 'config.xml',
+        [string[]] $EmailRequestConfigurationFilename = '*config*.xml',
 
         [Parameter()]
         [Alias('Mailbox')]
-        [string] $MailboxName
+        [string[]] $MailboxName
     )
     
     begin {
@@ -29,63 +29,39 @@ function Get-EasitEmailRequestMailbox {
     }
     
     process {
-        # Hmmm, this is not to effective. Same code as in Set-EasitEmailRequestMailboxSetting, will fix in version 2!!
-        try {
-            $erXmlConfigFile = Get-ChildItem -Path "$($emfConfig.EmailRequestRoot)" -Include "$EmailRequestConfigurationFilename" -Recurse -Force
-            Write-Verbose "Found ER config."
-        } catch {
-            throw $_
+        $erXmlConfigFiles = @()
+        foreach ($xmlConfigFilenames in $EmailRequestConfigurationFilename) {
+            try {
+                $erXmlConfigFiles += Get-ChildItem -Path "$($emfConfig.EmailRequestRoot)" -Include "$xmlConfigFilenames" -Recurse -Force
+            } catch {
+                throw $_
+            }
         }
-        try {
-            $erConfig = Import-EMFXMLData -Path "$($erXmlConfigFile.FullName)"
-            Write-Verbose "Imported configuration"
-        } catch {
-            throw $_
-        }
-        $mailboxes = @()
-        if ($null -eq $MailboxName) {
-            foreach ($mailboxConfig in $erConfig.configuration.entries.GetEnumerator()) {
-                $mailbox = New-Object PSObject
-                foreach ($property in $mailboxConfig.properties.GetEnumerator()) {
-                    Add-Member -InputObject $mailbox -MemberType Noteproperty -Name "$($property.name)" -Value "$($property.value)"
-                }
-                foreach ($sourceProperty in $mailboxConfig.source.properties.GetEnumerator()) {
-                    if ($sourceProperty.name -ne 'password') {
-                        Add-Member -InputObject $mailbox -MemberType Noteproperty -Name "$($sourceProperty.name)" -Value "$($sourceProperty.value)"
+        foreach ($erXmlConfigFile in $erXmlConfigFiles) {
+            if ($MailboxName) {
+                foreach ($Mailbox in $MailboxName) {
+                    if ($Mailbox -match '\*') {
+                        try {
+                            Convert-EmailRequestConfigfile $erXmlConfigFile | Where-Object {$_.displayName -Like "$Mailbox"}
+                        } catch {
+                            throw $_
+                        }
+                    } else {
+                        try {
+                            Convert-EmailRequestConfigfile $erXmlConfigFile | Where-Object {$_.displayName -eq "$Mailbox"}
+                        } catch {
+                            throw $_
+                        }
                     }
                 }
-                foreach ($destProperty in $mailboxConfig.destination.properties.GetEnumerator()) {
-                    Add-Member -InputObject $mailbox -MemberType Noteproperty -Name "$($destProperty.name)" -Value "$($destProperty.value)"
-                }
-                $mailboxes += $mailbox
-            }
-        } else { # Duplicate code again, will fix in version 2.
-            try {
-                $node = $erConfig.SelectNodes("//properties/property") | Where-Object {$_.name -eq "displayName"} | Where-Object {$_.value -eq "$MailboxName"}
-            } catch {
-                throw $_
-            }
-            try {
-                $mailBoxNode = $node.ParentNode.ParentNode
-                Write-Verbose "Found mailbox in configuration"
-            } catch {
-                throw $_
-            }
-            $mailbox = New-Object PSObject
-            foreach ($property in $mailBoxNode.properties.GetEnumerator()) {
-                Add-Member -InputObject $mailbox -MemberType Noteproperty -Name "$($property.name)" -Value "$($property.value)"
-            }
-            foreach ($sourceProperty in $mailBoxNode.source.properties.GetEnumerator()) {
-                if ($sourceProperty.name -ne 'password') {
-                    Add-Member -InputObject $mailbox -MemberType Noteproperty -Name "$($sourceProperty.name)" -Value "$($sourceProperty.value)"
+            } else {
+                try {
+                    Convert-EmailRequestConfigfile $erXmlConfigFile
+                } catch {
+                    throw $_
                 }
             }
-            foreach ($destProperty in $mailBoxNode.destination.properties.GetEnumerator()) {
-                Add-Member -InputObject $mailbox -MemberType Noteproperty -Name "$($destProperty.name)" -Value "$($destProperty.value)"
-            }
-            $mailboxes += $mailbox
         }
-        $mailboxes
     }
     
     end {


### PR DESCRIPTION
This pull request addresses both issue #95  and #94 .
- New private function "Convert-EmailRequestConfigfile" that parses a ER-config file and returns every mailbox as a PS object.
- Get-EasitEmailRequestMailbox parameters 'MailboxName' and 'EmailRequestConfigurationFilename' now supports multiple values.